### PR TITLE
Fixed a bug causing certain monsters on certain waves to spawn in the wrong place

### DIFF
--- a/tools/fight-caves/index.md
+++ b/tools/fight-caves/index.md
@@ -158,7 +158,7 @@ redirect_from:
 	top: 430px;
 	left: 200px;
 }
-.spawn-sw-offset {
+.spawn-se-offset {
 	position: absolute;
 	top: 365px;
 	left: 320px;


### PR DESCRIPTION
The bug was caused by the css class for `spawn-se-offset` being mistakenly called `spawn-sw-offset`. This had the effect of putting the `spawn-sw-offset` element to be placed where the the `spawn-se-offset` element should have been, and the `spawn-se-offset` element being positioned at the 0,0 location.